### PR TITLE
Fixed comments and added migration file for articles model

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -14,7 +14,7 @@ class ArticlesController < ApplicationController
             #returns validation errors if any occurs
             render json: @article.errors, status: :unprocessable_entity
         else
-            saves the article and returns appropriate response
+            #saves the article and returns appropriate response
             if @article.save
                 render json: @article, status: :created
             else
@@ -61,7 +61,7 @@ class ArticlesController < ApplicationController
         params.require(:article).permit(:title, :content, :author, :category, :published_at)
     end
 
-    restricts updating and deletion of articles
+    #restricts updating and deletion of articles
     def do_not_modify
         render json: {error: "Modifying or deleting articles is now alowed as it is public API"}, status: :method_not_allowed
     end

--- a/db/migrate/20250313233050_create_articles.rb
+++ b/db/migrate/20250313233050_create_articles.rb
@@ -1,0 +1,11 @@
+class CreateArticles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.string :content
+      t.string :author
+      t.string :category
+      t.date :published_at
+    end
+  end
+end


### PR DESCRIPTION
This PR corrects comments in the ArticlesController by adding missing # symbols. 
It also includes a migration file, which does not have timestamps since the tests do not compare created_at and updated_at. 
Alternatively, I have handled this in the code also by selecting only the required attributes articles_controller line 28